### PR TITLE
Fix --with-openca-tools-prefix in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -1652,9 +1652,9 @@ Optional Packages:
   --with-ldap-prefix=DIR  sets LDAP prefix (default is ldap)
   --with-pub-prefix=DIR   sets public gateway prefix (default is pub)
   --with-scep-prefix=DIR  sets SCEP prefix (default is scep)
-  --with-openca-tools-prefix=PREFIX/bin
-                          Prefix for openca-sv and openca-scep commands
-                          (default PREFIX/bin)
+  --with-openca-tools-prefix=PREFIX
+                          Prefix for openca-sv and openca-scep commands (this
+                          will search PREFIX/bin)
   --with-web-host=WEBHOST sets web hostname (http, ldap, ...)
   --with-prqp-server=URI  sets the PRQP server URI (default is
                           http://WEBHOST:830/)
@@ -13307,7 +13307,7 @@ fi
 
 
 
-		openca_tools_path="$openca_tools_prefix:$PATH:/bin:/usr/bin"
+		eval openca_tools_path="${bindir}:${exec_prefix}/bin:${prefix}/bin:${PATH}:/bin:/usr/bin"
 	if [ "x${openca_tools_prefix}" != "x" ]; then
 		openca_tools_path="${openca_tools_prefix}/bin"
 	fi

--- a/configure
+++ b/configure
@@ -13355,7 +13355,7 @@ fi
 
 
 	if [ "x$OPENCA_SV" = "xopenca-sv" ] ; then
-		as_fn_error $? "**** ERROR: can not find the openca-sv command, please install openca-tools package or use --with-openssl-tools-prefix option" "$LINENO" 5
+		as_fn_error $? "**** ERROR: can not find the openca-sv command, please install openca-tools package or use --with-openca-tools-prefix option" "$LINENO" 5
 	fi
 
 	# Extract the first word of "openca-scep", so it can be a program name with args.

--- a/configure.ac
+++ b/configure.ac
@@ -459,7 +459,7 @@ dnl AC_MSG_ERROR( [****** ($DIST_NAME) IBUILDER is : $ibuilder and INSTALL_BUILD
 		${openca_tools_path} )
 
 	if [[ "x$OPENCA_SV" = "xopenca-sv" ]] ; then
-		AC_MSG_ERROR([**** ERROR: can not find the openca-sv command, please install openca-tools] [package or use --with-openssl-tools-prefix option])
+		AC_MSG_ERROR([**** ERROR: can not find the openca-sv command, please install openca-tools] [package or use --with-openca-tools-prefix option])
 	fi
 
 	AC_PATH_PROG( OPENCA_SCEP, openca-scep, openca-scep,

--- a/configure.ac
+++ b/configure.ac
@@ -445,12 +445,12 @@ dnl AC_MSG_ERROR( [****** ($DIST_NAME) IBUILDER is : $ibuilder and INSTALL_BUILD
 	dnl fi
 
 	AC_ARG_WITH( openca-tools-prefix,
-		AC_HELP_STRING( [--with-openca-tools-prefix=PREFIX/bin], [Prefix for openca-sv and openca-scep commands (default PREFIX/bin)]),
+		AC_HELP_STRING( [--with-openca-tools-prefix=PREFIX], [Prefix for openca-sv and openca-scep commands (this will search PREFIX/bin)]),
 		openca_tools_prefix=$withval, openca_tools_prefix= )
 	AC_SUBST(openca_tools_prefix)
 
 	dnl Check for OpenCA Tools Installed
-	openca_tools_path="$openca_tools_prefix:$PATH:/bin:/usr/bin"
+	eval openca_tools_path="${bindir}:${exec_prefix}/bin:${prefix}/bin:${PATH}:/bin:/usr/bin"
 	if [[ "x${openca_tools_prefix}" != "x" ]]; then
 		openca_tools_path="${openca_tools_prefix}/bin"
 	fi


### PR DESCRIPTION
openca-base fails to build against relocated openca-tools installation and displays wrong error message.

Those commits fix the error message and try to remove the need to use --with-openca-tools-prefix at all if openca-base will be installed under same prefix(es) as openca-tools are already installed to.
